### PR TITLE
Adding error-id to notice template

### DIFF
--- a/app/views/airbrake/index.html.erb
+++ b/app/views/airbrake/index.html.erb
@@ -1,4 +1,5 @@
 <notice>
   <id><%= @issue.id %></id>
   <url><%= issue_url(@issue) %></url>
+  <error-id><%= @issue.id %></error-id>
 </notice>


### PR DESCRIPTION
The hoptoad notifier can display the error-id on the error page. You could use that to link back to the issue on redmine by including <!-- HOPTOAD ERROR --> in your error template and setting config.user_information to something like "Please refer to <a href="http://redmine.example.com/issues/{{error_id}}">#{{error_id}}</a>".

If error-id is not set in the notice template, the hoptoad notifier will just leave <!-- HOPTOAD ERROR --> alone. 
