### PR TITLE
configure default fixed version setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For a Rails application, just setup the Hoptoad notifier as usual, then modify `
 	                    :tracker => 'Bug',                           # the name of your desired tracker
 	                    :api_key => 'redmine_api_key',               # the key you generated in the previous step
 	                    :category => 'Development',                  # the name of a ticket category (optional.)
+                      :fixed_version => '25'                       # the default version (use is instead of name, optional.)
 	                    :assigned_to => 'admin',                     # the login of a user the ticket should get assigned to by default (optional.)
 	                    :login => 'airbrake',                        # the login who should be displayed as author of the tickets. Defaults to anonymous.
 	                    :reopen => 'production',                     # will only reopen if the error occurs on the specified environment. Defaults to all, optional.

--- a/app/controllers/airbrake_controller.rb
+++ b/app/controllers/airbrake_controller.rb
@@ -78,6 +78,7 @@ class AirbrakeController < ApplicationController
     @settings[:category] = IssueCategory.find_by_name(params[:category]) unless params[:category].blank?
     @settings[:assigned_to] = User.find_by_login(params[:assigned_to]) unless params[:assigned_to].blank?
     @settings[:priority] = params[:priority] unless params[:priority].blank?
+    @settings[:fixed_version] = params[:fixed_version] unless params[:fixed_version].blank?
   end
   
   def create_new_issue
@@ -87,6 +88,7 @@ class AirbrakeController < ApplicationController
     @issue.tracker = @settings[:tracker]
     @issue.project = @settings[:project]
     @issue.category = @settings[:category]
+    @issue.fixed_version_id = @settings[:fixed_version]
     @issue.assigned_to = @settings[:assigned_to]
     @issue.priority_id = @settings[:priority] unless @settings[:priority].nil?
     @issue.description = render_to_string(:partial => 'issue_description')


### PR DESCRIPTION
We develop systems in short iterations. We store these as versions in redmine. In parallel we also have a "hot fix" version which takes priority over all other work. This patch allows you to configure a default redmine version for the created issue. In our case we've hooked this up to the "hot fix" version.
