### PR TITLE
Issue subject and non-reopening of tickets with similar stack traces

### DIFF
--- a/app/controllers/airbrake_controller.rb
+++ b/app/controllers/airbrake_controller.rb
@@ -134,7 +134,7 @@ class AirbrakeController < ApplicationController
   end
    
   def build_subject
-    error_class = @notice['error']['class']
+    error_class = @notice['error']['message']
     # if there's only one line, it gets parsed into a hash instead of an array
     if @notice['error']['backtrace']['line'].is_a? Hash
       file = @notice['error']['backtrace']['line']['file']


### PR DESCRIPTION
I've run into a situation where I have two different exceptions, both with a top level stack trace that are the same, but in different locations of the code.

```
Subject: [Airbrake] NoMethodError in [PROJECT_ROOT]/vendor/ruby/1.9.1/gems/activemodel-3.1.3/lib/active_model/attribute_methods.rb:385

First line of Description: NoMethodError: undefined method `whatever_method?' for #<WhateverClass:0x0000000c052718>
```

VS

```
Subject: [Airbrake] NoMethodError in [PROJECT_ROOT]/vendor/ruby/1.9.1/gems/activemodel-3.1.3/lib/active_model/attribute_methods.rb:385

First line of Description: NoMethodError: undefined method `different_method?' for #<DifferentClass:0x0000000c052718>
```

So the problem is that when the first one gets created, the other refer's to that ticket, but the stack trace information is different, so It masks the second error, and we can't see where the problem is in the code.

I don't know if this is something we are causing or not, but it seems like it would be nice to have the first line of the description as the subject of the ticket.
